### PR TITLE
Adds mergesort big O tests

### DIFF
--- a/MergeSort/baselineTests/bubbleBaseline.js
+++ b/MergeSort/baselineTests/bubbleBaseline.js
@@ -1,5 +1,6 @@
 // from http://www.stoimen.com/blog/2010/07/09/friday-algorithms-javascript-bubble-sort/
-const bubbleSort = (a) => {
+const bubbleSort = (toBeSorted) => {
+  var a = toBeSorted.slice(0);
   var swapped;
   do {
     swapped = false;

--- a/MergeSort/baselineTests/bubbleBaseline.js
+++ b/MergeSort/baselineTests/bubbleBaseline.js
@@ -1,0 +1,17 @@
+// from http://www.stoimen.com/blog/2010/07/09/friday-algorithms-javascript-bubble-sort/
+const bubbleSort = (a) => {
+  var swapped;
+  do {
+    swapped = false;
+    for (var i=0; i < a.length-1; i++) {
+      if (a[i] > a[i+1]) {
+        var temp = a[i];
+        a[i] = a[i+1];
+        a[i+1] = temp;
+        swapped = true;
+      }
+    }
+  } while (swapped);
+}
+
+module.exports = bubbleSort

--- a/MergeSort/baselineTests/insertionBaseline.js
+++ b/MergeSort/baselineTests/insertionBaseline.js
@@ -1,0 +1,14 @@
+const insertionSort = (toBeSortedArray) => {
+  let array = toBeSortedArray.slice(0),
+    i, j;
+  for (let i = 0; i < array.length; i++) {
+    let value = array[i];
+    for (j = i - 1; j > -1 && array[j] > value; j--) {
+      array[j + 1] = array[j];
+    }
+    array[j + 1] = value;
+  }
+  return array;
+}
+
+module.exports = insertionSort;

--- a/MergeSort/mergeSort.js
+++ b/MergeSort/mergeSort.js
@@ -30,7 +30,11 @@ mergeSort.mergeSort = function (array) {
   const splits = mergeSort.split(array),
       left = splits[0],
       right = splits[1];
-  return mergeSort.merge(mergeSort.mergeSort(left), mergeSort.mergeSort(right));
+
+  let leftResult = left.length > 1 ? mergeSort.mergeSort(left) : left;
+  let rightResult = right.length > 1 ? mergeSort.mergeSort(right) : right;
+
+  return mergeSort.merge(leftResult, rightResult);
 }
 
 module.exports = mergeSort;

--- a/MergeSort/mergeSort.js
+++ b/MergeSort/mergeSort.js
@@ -25,14 +25,14 @@ mergeSort.merge = function (left, right) {
   return merged;
 }
 
-mergeSort.mergeSort = function (array) {
+mergeSort.main = function (array) {
   if (array.length < 2) return array;
   const splits = mergeSort.split(array),
       left = splits[0],
       right = splits[1];
 
-  let leftResult = left.length > 1 ? mergeSort.mergeSort(left) : left;
-  let rightResult = right.length > 1 ? mergeSort.mergeSort(right) : right;
+  let leftResult = left.length > 1 ? mergeSort.main(left) : left;
+  let rightResult = right.length > 1 ? mergeSort.main(right) : right;
 
   return mergeSort.merge(leftResult, rightResult);
 }

--- a/MergeSort/mergeSort.js
+++ b/MergeSort/mergeSort.js
@@ -1,21 +1,14 @@
 // From Full Stack Sorting Workshop
+const mergeSort = {};
 
-const mergeSort = function (array) {
-  if (array.length < 2) return array;
-  const splits = split(array),
-      left = splits[0],
-      right = splits[1];
-  return merge(mergeSort(left), mergeSort(right));
-}
-
-const split = function (array) {
+mergeSort.split = function (array) {
   const center = array.length / 2,
       left = array.slice(0, center),
       right = array.slice(center);
   return [left, right];
 }
 
-const merge = function (left, right) {
+mergeSort.merge = function (left, right) {
   const merged = [];
   let leftIdx = 0,
       rightIdx = 0;
@@ -32,8 +25,12 @@ const merge = function (left, right) {
   return merged;
 }
 
-module.exports = {
-  mergeSort,
-  split,
-  merge
-};
+mergeSort.mergeSort = function (array) {
+  if (array.length < 2) return array;
+  const splits = mergeSort.split(array),
+      left = splits[0],
+      right = splits[1];
+  return mergeSort.merge(mergeSort.mergeSort(left), mergeSort.mergeSort(right));
+}
+
+module.exports = mergeSort;

--- a/MergeSort/mergeSort.test.js
+++ b/MergeSort/mergeSort.test.js
@@ -1,53 +1,110 @@
 'use strict';
 
-const expect = require('chai').expect;
-const { mergeSort, split, merge } = require('./mergeSortStart');
+const chai = require('chai');
+const expect = chai.expect;
+// const spies = require('chai-spies');
+// chai.use(spies);
+const sinon = require('sinon');
+const chaiSinon = require('chai-sinon');
+chai.use(chaiSinon);
 
-xdescribe('Merge sort', function () {
+let { mergeSort, split, merge } = require('./mergeSort');
+let fns = require('./mergeSort');
 
-  describe('split', function () {
+describe.only('Merge sort', () => {
 
-    it('splits an array in half', function () {
+  describe('split', () => {
+
+    it('splits an array in half', () => {
       expect(split([])).to.deep.equal([[], []]);
     });
 
-    it('splits array of even length down the middle', function () {
+    it('splits array of even length down the middle', () => {
       expect(split([1, 2])).to.deep.equal([[1], [2]]);
     });
 
-    it('splits array of odd length down the middle, kind of', function () {
+    it('splits array of odd length down the middle, wighted to the right', () => {
       expect(split([1, 2, 3])).to.deep.equal([[1], [2, 3]]);
     });
 
   });
 
-  describe('merge', function () {
+  describe('merge', () => {
 
     it('combines two arrays into one', function () {
       expect(merge([], [])).to.deep.equal([]);
     });
 
-    it('combines two sorted arrays of deep.equal length into one sorted array', function () {
+    it('combines two sorted arrays of deep.equal length into one sorted array', () => {
       expect(merge([1, 3, 9], [2, 6, 15])).to.deep.equal([1, 2, 3, 6, 9, 15]);
       expect(merge([1, 2, 3, 4], [5, 6, 7, 8])).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8]);
     });
 
-    it('combines sorted arrays of unequal lengths into one sorted array', function () {
+    it('combines sorted arrays of unequal lengths into one sorted array', () => {
       expect(merge([1, 2, 3, 7, 9, 11], [4, 5, 50])).to.deep.equal([1, 2, 3, 4, 5, 7, 9, 11, 50]);
     });
 
   });
 
-  describe('mergeSort', function () {
+  describe('mergeSort', () => {
 
     it('returns a sorted array even if it\'s 0 or 1 elements long', function () {
       expect(mergeSort([])).to.deep.equal([]);
       expect(mergeSort([42])).to.deep.equal([42]);
     });
 
-    it('...actually merge sorts', function () {
+    it('sorts correctly', () => {
       const sorted = mergeSort([29, 8, 100, 17, 60, 43, -20]);
       expect(sorted).to.deep.equal([-20, 8, 17, 29, 43, 60, 100]);
+    });
+
+    describe('algorithmic complexity', () => {
+      let mergeSpy,
+          splitSpy,
+          mergeSortSpy,
+          originalMergeSort,
+          originalMerge,
+          originalSplit;
+
+      const toBeSortedFour = [4, 3, 2, 1];
+      const toBeSortedEight = [8, 7, 6, 5, 4, 3, 2, 1];
+
+      beforeEach('create spies', () => {
+        // originalMerge = fns.merge;
+        // originalSplit = fns.split;
+        // originalMergeSort = fns.mergeSort;
+        let spy = sinon.spy(fns, 'merge');
+        sinon.spy(fns, 'mergeSort');
+        sinon.spy(fns, 'split');
+        // console.log(fns);
+        // mergeSpy = sinon.spy(merge);
+        // splitSpy = sinon.spy(split);
+        // mergeSortSpy = sinon.spy(mergeSort);
+      });
+
+      afterEach('reset', () => {
+        // fns.merge = originalMerge;
+        // fns.split = originalSplit;
+        // fns.mergeSort = originalMergeSort;
+        fns.merge.restore();
+        fns.split.restore();
+        fns.mergeSort.restore();
+      });
+
+      it('calls split log n times', () => {
+        // console.log(fns.merge);
+        // console.log(fns.mergeSort);
+        fns.mergeSort(toBeSortedFour);
+        expect(fns.mergeSort).to.have.callCount(7);
+        expect(fns.split).to.have.been.called();
+        // expect(split).to.have.callCount(3);
+      });
+
+      it('calls mergeSort log n times', () => {
+        // mergeSort(toBeSortedEight);
+        // expect(mergeSortSpy).to.have.callCount(3)
+      });
+
     });
 
   });

--- a/MergeSort/mergeSort.test.js
+++ b/MergeSort/mergeSort.test.js
@@ -7,13 +7,14 @@ const sinon = require('sinon');
 const chaiSinon = require('chai-sinon');
 chai.use(chaiSinon);
 
-const { mergeSort, split, merge } = require('./mergeSort');
+const { split, merge } = require('./mergeSort');
+const mergeSort = require('./mergeSort').main;
 const mergeFuncs = require('./mergeSort');
 
 const insertionSort = require('./baselineTests/insertionBaseline');
 const bubbleSort = require('./baselineTests/bubbleBaseline');
 
-describe('Merge sort', () => {
+describe.only('Merge sort', () => {
 
   describe('split', () => {
 
@@ -65,24 +66,24 @@ describe('Merge sort', () => {
       const toBeSortedEight = [8, 7, 6, 5, 4, 3, 2, 1];
 
       beforeEach('populate spies', () => {
-        sinon.spy(mergeFuncs, 'mergeSort');
+        sinon.spy(mergeFuncs, 'main');
         sinon.spy(mergeFuncs, 'merge');
         sinon.spy(mergeFuncs, 'split');
       });
 
       afterEach('release spies', () => {
-        mergeFuncs.mergeSort.restore();
+        mergeFuncs.main.restore();
         mergeFuncs.merge.restore();
         mergeFuncs.split.restore();
       });
 
       it('uses recursion', () => {
-        mergeFuncs.mergeSort(toBeSortedFour);
-        expect(mergeFuncs.mergeSort.callCount).to.be.greaterThan(1);
+        mergeFuncs.main(toBeSortedFour);
+        expect(mergeFuncs.main.callCount).to.be.greaterThan(1);
       });
 
       it('calls the `merge` and `split` functions', () => {
-        mergeFuncs.mergeSort(toBeSortedEight);
+        mergeFuncs.main(toBeSortedEight);
         expect(mergeFuncs.merge.called).to.be.true;
         expect(mergeFuncs.split.called).to.be.true;
         expect(mergeFuncs.merge.callCount).to.be.greaterThan(1);
@@ -95,7 +96,8 @@ describe('Merge sort', () => {
       const toBeSortedSixteen = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
 
       it('is considerably faster than insertion sort or bubble sort with a large input set', function (done) {
-        // ensure that mocha doesn't time out. If you are on a slow machine, speed this up
+        // ensure that mocha doesn't time out.
+        // If you are on a slower machine and getting timeout errors, speed this up
         this.timeout(5000);
         // make a quite long array in very bad sorting order
         const toBeSortedLong = toBeSortedSixteen

--- a/MergeSort/mergeSortStart.js
+++ b/MergeSort/mergeSortStart.js
@@ -1,14 +1,16 @@
-const mergeSort = function (array) {
+const mergeSort = {};
+
+
+mergeSort.split = function (array) {
+
 }
 
-const split = function (array) {
+mergeSort.merge = function (left, right) {
+
 }
 
-const merge = function (left, right) {
+mergeSort.main = function (array) {
+
 }
 
-module.exports = {
-  mergeSort,
-  split,
-  merge
-};
+module.exports = mergeSort

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "dependencies": {
     "chai": "^3.5.0",
     "chai-properties": "^1.2.1",
+    "chai-sinon": "^2.8.1",
     "chai-spies": "^0.7.1",
-    "sinon": "^1.17.6",
+    "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
adds insertion and bubble sort baseline functions to mergeSort folder

tests that merge sort is faster than insertion or bubble sort by running a sort on a very large worst-case array and comparing times.

tests that mergeSort `main` function calls a `split` and `merge` helper function and works recursively

